### PR TITLE
fix loose semver handling

### DIFF
--- a/components/ModuleStats/ModuleStats.tsx
+++ b/components/ModuleStats/ModuleStats.tsx
@@ -1,5 +1,5 @@
 import { type FC, Fragment, useMemo, useState } from "react";
-import { major as semverMajor } from "semver";
+import semverParse from "semver/functions/parse";
 import {
   XYChart,
   BarSeries,
@@ -119,6 +119,14 @@ const ChartTooltip: FC<{ datum: ChartDatum }> = (props) => (
     <p>Downloads: {numberFormatter.format(accessors.yAccessor(props.datum))}</p>
   </Fragment>
 );
+
+function semverMajor(version: string): number {
+  const majorVersion = semverParse(version, { loose: true })?.major;
+  if (majorVersion === undefined) {
+    throw new Error(`Wasn't able to parse "${version}" semver string.`);
+  }
+  return majorVersion;
+}
 
 const majorVersionRange = (majorVersion: number): string => `${majorVersion}.X`;
 

--- a/lib/ChartDatum.ts
+++ b/lib/ChartDatum.ts
@@ -1,4 +1,5 @@
 import { compare as compareSemver } from "semver";
+import semverParse from "semver/functions/parse";
 import { type Compare, compareKey, compareNumber } from "./sort";
 
 export interface ChartDatum {
@@ -7,10 +8,13 @@ export interface ChartDatum {
   readonly downloads: number;
 }
 
-export const compareVersion: Compare<ChartDatum> = compareKey(
-  (i) => i.version,
-  compareSemver
-);
+export const compareVersion: Compare<ChartDatum> = compareKey((i) => {
+  const version = semverParse(i.version, { loose: true })?.version;
+  if (version === undefined) {
+    throw new Error(`Wasn't able to parse "${i.version}" semver string.`);
+  }
+  return version;
+}, compareSemver);
 export const compareDownloads: Compare<ChartDatum> = compareKey(
   (i) => i.downloads,
   compareNumber

--- a/lib/mocks/api/handlers.ts
+++ b/lib/mocks/api/handlers.ts
@@ -70,4 +70,12 @@ const moduleData: Record<string, ModuleData | undefined> =
       },
       deprecations: [],
     },
+    loose: {
+      // NOTE: grunt has old version numbers like this. These require loose semver parsing.
+      versionsDownloads: {
+        "0.4.0a": 50,
+        "0.4.0rc2": 100,
+      },
+      deprecations: [],
+    },
   });


### PR DESCRIPTION
This sets the loose option to true when parsing semver strings.

I ran into some loose versions like "0.4.0a" in the `grunt` module.